### PR TITLE
quickfixed PHP-Warning Message for inlineLink

### DIFF
--- a/vendor/erusev/parsedown-extra/ParsedownExtra.php
+++ b/vendor/erusev/parsedown-extra/ParsedownExtra.php
@@ -302,6 +302,10 @@ class ParsedownExtra extends Parsedown
     protected function inlineLink($Excerpt)
     {
         $Link = parent::inlineLink($Excerpt);
+        
+        if ( is_null($Link) || is_null($Link['extent'])) {
+            return null;
+        }
 
         $remainder = substr($Excerpt['text'], $Link['extent']);
 


### PR DESCRIPTION
return NULL-value for invalid inputs

for more information:
#5 