### PR TITLE
enable "URL-Rewriting" enabled instances to use checkboxes & add html validation

### DIFF
--- a/Assets/js/checkbox.js
+++ b/Assets/js/checkbox.js
@@ -10,17 +10,23 @@ KB.on('dom.ready', function () {
         function ToggleActiveCheckbox(e) {
             const urlParams = new URLSearchParams(window.location.search);
 
+            var task_id = null;
+            var taskIdElem = document.getElementById('form-task_id');
+            if (taskIdElem != null) {
+                task_id = taskIdElem.value;
+            }
+
             if (URLRewrite) {
                 const link = '/MarkdownPlus/Checkbox';
                 KB.http.postJson(link, {
-                    'task_id': urlParams.get('task_id'),
+                    'task_id': task_id,
                     'number': e.target.getAttribute('number')
                 });
             }
             else {
                 const link = '?controller=CheckboxController&action=toggle&plugin=MarkdownPlus';
                 KB.http.postJson(link, {
-                    'task_id': urlParams.get('task_id'),
+                    'task_id': task_id,
                     'number': e.target.getAttribute('number')
                 });
             }

--- a/Assets/js/checkbox.js
+++ b/Assets/js/checkbox.js
@@ -1,34 +1,29 @@
-KB.on('dom.ready', function() {
+KB.on('dom.ready', function () {
     const urlParams = new URLSearchParams(window.location.search);
-    if ((urlParams.get('controller') == "TaskViewController" && urlParams.get('action') == 'show') || /\/task\/[0-9]+$/.test(window.location)) {
-        var Content = document.getElementsByClassName('sidebar-content')[0];
 
-        const elements = [...Content.getElementsByTagName('input')];
-        var checkboxes = elements.filter(input=>input.type == 'checkbox');
-        const matches = [...Content.innerHTML.matchAll(RegExp('(<input type="checkbox")|(\\[[xX ]\\])', 'gm'))];
-
-        var count = 0;
-        var currentCheckbox = 0;
-        for (const match of matches) {
-            ++count;
-            if (match[1] !== undefined) {
-                var checkbox = checkboxes[currentCheckbox];
-                checkbox.setAttribute('class', 'activecheckbox');
-                checkbox.setAttribute('number', count);
-                ++currentCheckbox;
-            }
-        }
+    let URLRewrite = /\/task\/[0-9]+$/.test(window.location);
+    if ((urlParams.get('controller') == "TaskViewController" && urlParams.get('action') == 'show') ||
+        URLRewrite) { // for activated URL-Rewrite
 
         KB.onClick('.activecheckbox', ToggleActiveCheckbox, !0);
 
         function ToggleActiveCheckbox(e) {
             const urlParams = new URLSearchParams(window.location.search);
 
-            const link = '?controller=CheckboxController&action=toggle&plugin=MarkdownPlus';
-            KB.http.postJson(link, {
-                'task_id': urlParams.get('task_id'),
-                'number': e.target.getAttribute('number')
-            });
+            if (URLRewrite) {
+                const link = '/MarkdownPlus/Checkbox';
+                KB.http.postJson(link, {
+                    'task_id': urlParams.get('task_id'),
+                    'number': e.target.getAttribute('number')
+                });
+            }
+            else {
+                const link = '?controller=CheckboxController&action=toggle&plugin=MarkdownPlus';
+                KB.http.postJson(link, {
+                    'task_id': urlParams.get('task_id'),
+                    'number': e.target.getAttribute('number')
+                });
+            }
         }
     }
 });

--- a/Assets/js/checkbox.js
+++ b/Assets/js/checkbox.js
@@ -16,20 +16,18 @@ KB.on('dom.ready', function () {
                 task_id = taskIdElem.value;
             }
 
+            let link = "";
             if (URLRewrite) {
-                const link = '/MarkdownPlus/Checkbox';
-                KB.http.postJson(link, {
-                    'task_id': task_id,
-                    'number': e.target.getAttribute('number')
-                });
+                link = '/MarkdownPlus/Checkbox';
             }
             else {
-                const link = '?controller=CheckboxController&action=toggle&plugin=MarkdownPlus';
-                KB.http.postJson(link, {
-                    'task_id': task_id,
-                    'number': e.target.getAttribute('number')
-                });
+                link = '?controller=CheckboxController&action=toggle&plugin=MarkdownPlus';
             }
+            
+            KB.http.postJson(link, {
+                'task_id': task_id,
+                'number': e.target.getAttribute('number')
+            });
         }
     }
 });

--- a/Plugin.php
+++ b/Plugin.php
@@ -3,7 +3,6 @@
 namespace Kanboard\Plugin\MarkdownPlus;
 
 use Kanboard\Core\Plugin\Base;
-use Kanboard\Plugin\MarkdownPlus\Helper\MarkdownPlusHelper;
 
 class Plugin extends Base
 

--- a/vendor/erusev/parsedown-extra/ParsedownExtra.php
+++ b/vendor/erusev/parsedown-extra/ParsedownExtra.php
@@ -629,6 +629,17 @@ class ParsedownExtra extends Parsedown
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);
+        
+        if (!$DOMDocument->validate()) {
+            $errormessage = 'could not parse html<br>';
+            $errors = libxml_get_errors();
+            foreach ($errors as $error) {
+                $errormessage .= $error->message;
+                $errormessage .= '<br>';
+            }
+            return $errormessage;
+        }
+
         $DOMDocument->removeChild($DOMDocument->doctype);
         $DOMDocument->replaceChild($DOMDocument->firstChild->firstChild->firstChild, $DOMDocument->firstChild);
 

--- a/vendor/leblanc-simon/parsedown-checkbox/ParsedownCheckbox.php
+++ b/vendor/leblanc-simon/parsedown-checkbox/ParsedownCheckbox.php
@@ -11,6 +11,7 @@
 class ParsedownCheckbox extends ParsedownExtra
 {
     const VERSION = '0.0.4';
+    private static $count = 1;
 
     public function __construct()
     {
@@ -73,7 +74,7 @@ class ParsedownCheckbox extends ParsedownExtra
             $text = self::escape($text);
         }
 
-        return '<input type="checkbox" class="activeCheckBox"/> ' . $this->format($text);
+        return '<input type="checkbox" class="activecheckbox" number="'. ParsedownCheckbox::$count++ .'"/> ' . $this->format($text);
     }
 
     protected function checkboxChecked($text)
@@ -82,7 +83,7 @@ class ParsedownCheckbox extends ParsedownExtra
             $text = self::escape($text);
         }
 
-        return '<input type="checkbox" class="activeCheckBox" checked/> ' . $this->format($text);
+        return '<input type="checkbox" class="activecheckbox" number="'. ParsedownCheckbox::$count++ .'" checked/> ' . $this->format($text);
     }
 
     /**


### PR DESCRIPTION
MarkdownPlus now fully supports checkboxes on instances that use URL-Rewriting.

There also was a problem with activated `MARKDOWN_ESCAPE_HTML` if an invalid tag was placed somewhere.

The HTML is now validated and errors will be displayed to the user.

Developed with the help of https://github.com/Tagirijus