### PR TITLE
Update Parsedown and ParsedownExtra for PHP 8.4/8.5 compatibility

### DIFF
--- a/vendor/erusev/parsedown-extra/ParsedownExtra.php
+++ b/vendor/erusev/parsedown-extra/ParsedownExtra.php
@@ -6,7 +6,7 @@
 # https://github.com/erusev/parsedown-extra
 #
 # (c) Emanuil Rusev
-# http://erusev.com
+# https://erusev.com
 #
 # For the full license information, view the LICENSE file that was distributed
 # with this source code.
@@ -17,15 +17,15 @@ class ParsedownExtra extends Parsedown
 {
     # ~
 
-    const version = '0.8.0';
+    const version = '0.9.0';
 
     # ~
 
     function __construct()
     {
-        if (version_compare(parent::version, '1.7.1') < 0)
+        if (version_compare(parent::version, '1.8.0') < 0)
         {
-            throw new Exception('ParsedownExtra requires a later version of Parsedown');
+            throw new Exception('ParsedownExtra requires Parsedown 1.8.0 or later');
         }
 
         $this->BlockTypes[':'] []= 'DefinitionList';
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], [$this, 'sortFootnotes']);
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {
@@ -545,7 +545,7 @@ class ParsedownExtra extends Parsedown
 
             $n = count($textElements) -1;
 
-            if ($textElements[$n]['name'] === 'p')
+            if (isset($textElements[$n]['name']) && $textElements[$n]['name'] === 'p')
             {
                 $backLinkElements = array_merge(
                     array(
@@ -625,33 +625,15 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        $elementMarkup = mb_encode_numericentity(
+            $elementMarkup,
+            [0x80, 0x10FFFF, 0, ~0],
+            'UTF-8'
+        );
 
         # http://stackoverflow.com/q/4879946/200145
-        $success = $DOMDocument->loadHTML($elementMarkup);
+        $DOMDocument->loadHTML($elementMarkup);
         $DOMDocument->removeChild($DOMDocument->doctype);
-
-        $errors = libxml_get_errors();
-        if ($errors)
-        {
-            $errormessage = "<h1>HTML-parser error:</h1><br>";
-            $errormessage .= "The input was interpret as HTML - did you miss the <code>markdown=1</code> attribute?<br>";
-            foreach ($errors as $error) {
-                $errormessage .= "Line: " . $error->line . " - " . $error->message;
-                $errormessage .= '<br>';
-            }
-            return $errormessage;
-        }
-
-        if (!isset($DOMDocument->firstChild->firstChild->firstChild))
-        {
-            $errormessage = "<h1>General HTML-parser error:</h1><br>";
-            $errormessage .= "The input was interpret as HTML - did you miss the <code>markdown=1</code> attribute?<br>";
-            $errormessage .= "Input:<pre><code>" . htmlspecialchars($elementMarkup) . "</code></pre>";
-            $errormessage .= "Output:<pre><code>" . htmlspecialchars($DOMDocument->saveHTML()) . "</code></pre>";
-            return $errormessage;
-        }
-
         $DOMDocument->replaceChild($DOMDocument->firstChild->firstChild->firstChild, $DOMDocument->firstChild);
 
         $elementText = '';

--- a/vendor/erusev/parsedown/Parsedown.php
+++ b/vendor/erusev/parsedown/Parsedown.php
@@ -17,7 +17,7 @@ class Parsedown
 {
     # ~
 
-    const version = '1.8.0-beta-7';
+    const version = '1.8.0';
 
     # ~
 
@@ -1502,8 +1502,6 @@ class Parsedown
                 'extent' => strlen($matches[0]),
             );
         }
-
-        return;
     }
 
     protected function inlineStrikethrough($Excerpt)
@@ -1851,6 +1849,9 @@ class Parsedown
     # Deprecated Methods
     #
 
+    /**
+     * @deprecated use text() instead
+     */
     function parse($text)
     {
         $markup = $this->text($text);
@@ -1977,7 +1978,7 @@ class Parsedown
     protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
 
     protected $voidElements = array(
-        'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source'
+        'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source',
     );
 
     protected $textLevelElements = array(


### PR DESCRIPTION
This PR updates two vendored dependencies to fix deprecation warnings introduced in PHP 8.4 and causing issues in PHP 8.5:
Parsedown 1.8.0-beta-7 → 1.8.0
ParsedownExtra 0.8.0 → 0.9.0

Both releases were published on February 16, 2026 and are tested against PHP 7.1 through 8.4.
Tested with: Kanboard 1.2.52, PHP 8.5